### PR TITLE
feat(graphql-codegen-zod): add custom imports support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -55,7 +55,7 @@
     },
     "packages/client": {
       "name": "@use-pico/client",
-      "version": "5.0.220",
+      "version": "5.0.222",
       "dependencies": {
         "@floating-ui/react": "0.27.16",
         "@lexical/list": "0.37.0",
@@ -99,7 +99,7 @@
     },
     "packages/cls": {
       "name": "@use-pico/cls",
-      "version": "5.0.68",
+      "version": "5.0.69",
       "dependencies": {
         "react": "19.2.0",
         "tailwind-merge": "3.3.1",
@@ -127,7 +127,7 @@
     },
     "packages/common": {
       "name": "@use-pico/common",
-      "version": "5.0.94",
+      "version": "5.0.95",
       "dependencies": {
         "@apollo/client": "4.0.7",
         "@graphql-typed-document-node/core": "3.2.0",
@@ -169,7 +169,7 @@
     },
     "packages/graphql-codegen-zod": {
       "name": "@use-pico/graphql-codegen-zod",
-      "version": "4.0.60",
+      "version": "4.0.61",
       "dependencies": {
         "@graphql-codegen/add": "6.0.0",
         "@graphql-codegen/import-types-preset": "3.0.1",
@@ -188,6 +188,8 @@
         "rollup": "4.52.5",
         "rollup-plugin-dts": "6.2.3",
         "typescript": "^5.9.3",
+        "vitest": "4.0.1",
+        "zod": "4.1.12",
       },
     },
     "packages/llm": {
@@ -199,7 +201,7 @@
     },
     "packages/server": {
       "name": "@use-pico/server",
-      "version": "5.0.98",
+      "version": "5.0.99",
       "dependencies": {
         "@phenomnomnominal/tsquery": "6.1.3",
         "@types/cli-progress": "3.11.6",

--- a/packages/graphql-codegen-zod/README.md
+++ b/packages/graphql-codegen-zod/README.md
@@ -98,6 +98,7 @@ Map custom GraphQL scalar types to Zod schema definitions.
 ```typescript
 interface Config {
   scalars?: Record<string, string>;
+  imports?: string[];
 }
 ```
 
@@ -108,6 +109,27 @@ config:
     DateTime: 'z.date()'
     JSON: 'z.any()'
     CustomScalar: 'z.string().transform(val => customTransform(val))'
+```
+
+### `imports`
+Add custom import statements to the generated file. This is useful when using custom scalar validators from external libraries.
+
+**Example:**
+```yaml
+config:
+  scalars:
+    AWSDateTime: 'zInstant'
+  imports:
+    - 'import { zInstant } from "temporal-zod";'
+```
+
+With this configuration, the generated file will include:
+```typescript
+/* eslint-disable no-use-before-define */
+import { z } from "zod";
+import { zInstant } from "temporal-zod";
+
+// ... your generated schemas using zInstant
 ```
 
 ## Generated Output

--- a/packages/graphql-codegen-zod/package.json
+++ b/packages/graphql-codegen-zod/package.json
@@ -6,7 +6,8 @@
 	"sideEffects": false,
 	"scripts": {
 		"typecheck": "tsc --noEmit",
-		"build": "bun x rollup -c"
+		"build": "bun x rollup -c",
+		"test": "vitest --run"
 	},
 	"dependencies": {
 		"@graphql-codegen/add": "6.0.0",
@@ -25,7 +26,9 @@
 		"@use-pico/tsconfig": "5.0.0",
 		"rollup": "4.52.5",
 		"rollup-plugin-dts": "6.2.3",
-		"typescript": "^5.9.3"
+		"typescript": "^5.9.3",
+		"vitest": "4.0.1",
+		"zod": "4.1.12"
 	},
 	"main": "dist/index.js",
 	"module": "dist/index.js",

--- a/packages/graphql-codegen-zod/src/index.ts
+++ b/packages/graphql-codegen-zod/src/index.ts
@@ -32,6 +32,8 @@ export namespace withZodPlugin {
 	export interface Config {
 		/** Custom scalar type mappings for GraphQL to Zod conversion */
 		scalars?: Record<string, string>;
+		/** Custom import statements to include in the generated file */
+		imports?: string[];
 	}
 }
 
@@ -960,6 +962,7 @@ export const withZodPlugin: PluginFunction<withZodPlugin.Config> = (
 	// Merge config with defaults
 	const finalConfig: Required<withZodPlugin.Config> = {
 		scalars: config.scalars || {},
+		imports: config.imports || [],
 	};
 
 	try {
@@ -967,6 +970,11 @@ export const withZodPlugin: PluginFunction<withZodPlugin.Config> = (
 			`/* eslint-disable no-use-before-define */`,
 			`import { z } from "zod";`,
 		];
+
+		// Add custom imports if provided
+		if (finalConfig.imports.length > 0) {
+			output.push(...finalConfig.imports);
+		}
 
 		// Create visited types tracker for this execution
 		const visitedTypes = new Set<string>();

--- a/packages/graphql-codegen-zod/test/custom-imports.test.ts
+++ b/packages/graphql-codegen-zod/test/custom-imports.test.ts
@@ -1,0 +1,135 @@
+import { buildSchema } from "graphql";
+import { describe, expect, it } from "vitest";
+import { withZodPlugin } from "../src/index";
+
+describe("Custom Imports", () => {
+	const schema = buildSchema(`
+		scalar AWSDateTime
+		scalar CustomScalar
+
+		type User {
+			id: ID!
+			name: String
+			createdAt: AWSDateTime!
+			metadata: CustomScalar
+		}
+
+		type Query {
+			user(id: ID!): User
+		}
+	`);
+
+	it("should include custom imports in generated output", () => {
+		const config = {
+			scalars: {
+				AWSDateTime: "zInstant",
+				CustomScalar: "customScalar",
+			},
+			imports: [
+				'import { zInstant } from "temporal-zod";',
+				'import { customScalar } from "./custom-scalars";',
+			],
+		};
+
+		const result = withZodPlugin(schema, [], config) as string;
+
+		// Check that the default zod import is present
+		expect(result).toContain('import { z } from "zod";');
+
+		// Check that custom imports are included
+		expect(result).toContain('import { zInstant } from "temporal-zod";');
+		expect(result).toContain(
+			'import { customScalar } from "./custom-scalars";',
+		);
+
+		// Verify custom imports appear after the zod import
+		const zodImportIndex = result.indexOf('import { z } from "zod";');
+		const temporalImportIndex = result.indexOf(
+			'import { zInstant } from "temporal-zod";',
+		);
+		const customImportIndex = result.indexOf(
+			'import { customScalar } from "./custom-scalars";',
+		);
+
+		expect(temporalImportIndex).toBeGreaterThan(zodImportIndex);
+		expect(customImportIndex).toBeGreaterThan(zodImportIndex);
+	});
+
+	it("should use custom scalar types in generated schemas", () => {
+		const config = {
+			scalars: {
+				AWSDateTime: "zInstant",
+				CustomScalar: "customScalar",
+			},
+			imports: [
+				'import { zInstant } from "temporal-zod";',
+			],
+		};
+
+		const result = withZodPlugin(schema, [], config) as string;
+
+		// Check that the User schema uses the custom scalar types
+		expect(result).toContain("createdAt: zInstant");
+		expect(result).toContain("metadata: customScalar");
+	});
+
+	it("should work without custom imports", () => {
+		const config = {
+			scalars: {
+				AWSDateTime: "z.date()",
+			},
+		};
+
+		const result = withZodPlugin(schema, [], config) as string;
+
+		// Check that only the default zod import is present
+		expect(result).toContain('import { z } from "zod";');
+
+		// Check that no temporal-zod import is present
+		expect(result).not.toContain("temporal-zod");
+
+		// Check that the schema uses the standard zod type
+		expect(result).toContain("createdAt: z.date()");
+	});
+
+	it("should handle empty imports array", () => {
+		const config = {
+			scalars: {
+				AWSDateTime: "z.date()",
+			},
+			imports: [],
+		};
+
+		const result = withZodPlugin(schema, [], config) as string;
+
+		// Check that only the default zod import is present
+		expect(result).toContain('import { z } from "zod";');
+
+		// Verify no extra imports
+		const importLines = result
+			.split("\n")
+			.filter((line) => line.includes("import"));
+		expect(importLines.length).toBe(1); // only zod import
+	});
+
+	it("should handle multiple custom imports", () => {
+		const config = {
+			imports: [
+				'import { zInstant } from "temporal-zod";',
+				'import { customScalar } from "./custom-scalars";',
+				'import { anotherValidator } from "./validators";',
+			],
+		};
+
+		const result = withZodPlugin(schema, [], config) as string;
+
+		// All imports should be present
+		expect(result).toContain('import { zInstant } from "temporal-zod";');
+		expect(result).toContain(
+			'import { customScalar } from "./custom-scalars";',
+		);
+		expect(result).toContain(
+			'import { anotherValidator } from "./validators";',
+		);
+	});
+});

--- a/packages/graphql-codegen-zod/vitest.config.ts
+++ b/packages/graphql-codegen-zod/vitest.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	// Vite optimizations for faster builds
+	build: {
+		target: "esnext",
+		minify: false, // Disable minification for faster builds
+	},
+	// Optimize dependencies
+	optimizeDeps: {
+		include: [
+			"vitest",
+		],
+	},
+	// Cache directory for better performance
+	cacheDir: "./node_modules/.vite",
+	test: {
+		globals: true,
+		include: [
+			"test/**/*.test.ts",
+		],
+		passWithNoTests: true,
+		isolate: false,
+		sequence: {
+			shuffle: false,
+		},
+		coverage: {
+			enabled: false,
+		},
+		ui: false,
+	},
+});


### PR DESCRIPTION
Resolves https://github.com/use-pico/pico/issues/17

Add imports configuration option to allow custom import statements in generated files. This enables users to import custom scalar validators from external libraries.

Changes:
- Add imports config option to `withZodPlugin.Config` interface
- Update implementation to append custom imports after default zod import
- Add vitest test infrastructure
- Add comprehensive test suite for custom imports feature
- Update README with imports configuration documentation
- Bump package versions: `@use-pico/client` to 5.0.222, `@use-pico/cls` to 5.0.69, `@use-pico/common` to 5.0.95, `@use-pico/graphql-codegen-zod` to 4.0.61, `@use-pico/server` to 5.0.99